### PR TITLE
trim any extra null characters to the right when parsing string arrays

### DIFF
--- a/pkg/package.go
+++ b/pkg/package.go
@@ -356,11 +356,7 @@ func uint16Array(data []byte, arraySize int) ([]uint16, error) {
 }
 
 func parseStringArray(data []byte) []string {
-	elements := strings.Split(string(data), "\x00")
-	if len(elements) > 0 && elements[len(elements)-1] == "" {
-		return elements[:len(elements)-1]
-	}
-	return elements
+	return strings.Split(string(bytes.TrimRight(data, "\x00")), "\x00")
 }
 
 func (p *PackageInfo) InstalledFileNames() ([]string, error) {


### PR DESCRIPTION
*Description of changes:*

Currently the `parseStringArray` method will only drop a single occurrence of `\x00` at the end of a byte slice, but this updates it to trim all of them.

Specifically, we have encountered some cases where calling `InstalledFileNames` fails due to the presence of extra `\x00` at the end of the `DIRNAMES` tag for some rpm entries (though they work fine when using `rpm` queries directly).

We do have [an rpm database](https://github.com/anchore/test-images/tree/main/containers/analyzer-ensure-no-failure-on-unparseable-records/rpm) which encounters this case.  `InstalledFileNames` will return an error when parsing the following entries:

- ALATPAselinuxlocalization
- ALATPAcloudinit
- ALATPAsecurity
- ALATPAaerospikeservercnf

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>
