### PR TITLE
prof: specify `length` and `capacity` at initialization

### DIFF
--- a/pkg/bdb/hash_page.go
+++ b/pkg/bdb/hash_page.go
@@ -47,7 +47,7 @@ func HashPageValueContent(db *os.File, pageData []byte, hashPageIndex uint16, pa
 		return nil, err
 	}
 
-	var hashValue []byte
+	hashValue := make([]byte, 16000, 64000)
 
 	for currentPageNo := entry.PageNo; currentPageNo != 0; {
 		pageStart := pageSize * currentPageNo


### PR DESCRIPTION
*Issue:* `append` reallocates memory too many times.

*Description of changes:* specify `length` and `capacity`.

before:
![изображение](https://user-images.githubusercontent.com/19297627/207719040-95a7110d-d96c-4796-9048-8e3e7877fc77.png)

after:
![изображение](https://user-images.githubusercontent.com/19297627/207719098-b6af5f6b-636c-4054-93c7-deba86ff88e6.png)

