### PR TITLE
fix panic in scanning rows when query fails

### DIFF
--- a/pkg/sqlite3/sqlite3.go
+++ b/pkg/sqlite3/sqlite3.go
@@ -62,6 +62,13 @@ func (db *SQLite3) Read() <-chan dbi.Entry {
 			}
 		}
 
+		if rows == nil {
+			entries <- dbi.Entry{
+				Err: xerrors.Errorf("query failed to return rows: %w", err),
+			}
+			return
+		}
+
 		for rows.Next() {
 			var blob string
 			if err := rows.Scan(&blob); err != nil {


### PR DESCRIPTION
*Description of changes:*

Fixing a bug in the sqlite RPMDB implementation where reading from Packages (SELECT blob FROM Packages) failing would cause a panic when calling rows.Next() due to rows being nil.

Signed-off-by: Jose R. Gonzalez [jose@flutes.dev](mailto:jose@flutes.dev)

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
