### PR TITLE
Add missing file.Close() for bdb and ndb

### DIFF
--- a/pkg/bdb/bdb.go
+++ b/pkg/bdb/bdb.go
@@ -57,12 +57,15 @@ func Open(path string) (*BerkeleyDB, error) {
 	}, nil
 }
 
+func (db *BerkeleyDB) Close() error {
+	return db.file.Close()
+}
+
 func (db *BerkeleyDB) Read() <-chan dbi.Entry {
 	entries := make(chan dbi.Entry)
 
 	go func() {
 		defer close(entries)
-		defer db.file.Close()
 
 		for pageNum := uint32(0); pageNum <= db.HashMetadata.LastPageNo; pageNum++ {
 			pageData, err := slice(db.file, int(db.HashMetadata.PageSize))

--- a/pkg/bdb/bdb.go
+++ b/pkg/bdb/bdb.go
@@ -62,6 +62,7 @@ func (db *BerkeleyDB) Read() <-chan dbi.Entry {
 
 	go func() {
 		defer close(entries)
+		defer db.file.Close()
 
 		for pageNum := uint32(0); pageNum <= db.HashMetadata.LastPageNo; pageNum++ {
 			pageData, err := slice(db.file, int(db.HashMetadata.PageSize))

--- a/pkg/db/rpmdbinterface.go
+++ b/pkg/db/rpmdbinterface.go
@@ -7,4 +7,5 @@ type Entry struct {
 
 type RpmDBInterface interface {
 	Read() <-chan Entry
+	Close() error
 }

--- a/pkg/ndb/ndb.go
+++ b/pkg/ndb/ndb.go
@@ -131,6 +131,7 @@ func (db *RpmNDB) Read() <-chan dbi.Entry {
 
 	go func() {
 		defer close(entries)
+		defer db.file.Close()
 
 		const NDB_BlobHeaderSize = int64(unsafe.Sizeof(ndbBlobHeader{}))
 

--- a/pkg/ndb/ndb.go
+++ b/pkg/ndb/ndb.go
@@ -126,12 +126,15 @@ func Open(path string) (*RpmNDB, error) {
 	}, nil
 }
 
+func (db *RpmNDB) Close() error {
+	return db.file.Close()
+}
+
 func (db *RpmNDB) Read() <-chan dbi.Entry {
 	entries := make(chan dbi.Entry)
 
 	go func() {
 		defer close(entries)
-		defer db.file.Close()
 
 		const NDB_BlobHeaderSize = int64(unsafe.Sizeof(ndbBlobHeader{}))
 

--- a/pkg/rpmdb.go
+++ b/pkg/rpmdb.go
@@ -42,6 +42,10 @@ func Open(path string) (*RpmDB, error) {
 
 }
 
+func (d *RpmDB) Close() error {
+	return d.db.Close()
+}
+
 func (d *RpmDB) Package(name string) (*PackageInfo, error) {
 	pkgs, err := d.ListPackages()
 	if err != nil {

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -757,6 +757,9 @@ func TestRpmDB_Package(t *testing.T) {
 			got.GroupNames = nil
 
 			assert.Equal(t, tt.want, got)
+
+			err = db.Close()
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Fixes `pkg/ndb` and `pkg/bdb` packages which do not close their underlying file.