### PR TITLE
Adding a timeout to fix infinite looping on corrupt bdb database files.

### DIFF
--- a/pkg/db/rpmdbinterface.go
+++ b/pkg/db/rpmdbinterface.go
@@ -1,11 +1,13 @@
 package dbi
 
+import "context"
+
 type Entry struct {
 	Value []byte
 	Err   error
 }
 
 type RpmDBInterface interface {
-	Read() <-chan Entry
+	Read(ctx context.Context) <-chan Entry
 	Close() error
 }

--- a/pkg/ndb/ndb.go
+++ b/pkg/ndb/ndb.go
@@ -22,6 +22,7 @@ SOFTWARE.
 package ndb
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -130,7 +131,7 @@ func (db *RpmNDB) Close() error {
 	return db.file.Close()
 }
 
-func (db *RpmNDB) Read() <-chan dbi.Entry {
+func (db *RpmNDB) Read(ctx context.Context) <-chan dbi.Entry {
 	entries := make(chan dbi.Entry)
 
 	go func() {

--- a/pkg/rpmdb.go
+++ b/pkg/rpmdb.go
@@ -1,6 +1,7 @@
 package rpmdb
 
 import (
+	"context"
 	"github.com/knqyf263/go-rpmdb/pkg/bdb"
 	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
 	"github.com/knqyf263/go-rpmdb/pkg/ndb"
@@ -47,7 +48,11 @@ func (d *RpmDB) Close() error {
 }
 
 func (d *RpmDB) Package(name string) (*PackageInfo, error) {
-	pkgs, err := d.ListPackages()
+	return d.PackageWithContext(context.TODO(), name)
+}
+
+func (d *RpmDB) PackageWithContext(ctx context.Context, name string) (*PackageInfo, error) {
+	pkgs, err := d.ListPackagesWithContext(ctx)
 	if err != nil {
 		return nil, xerrors.Errorf("unable to list packages: %w", err)
 	}
@@ -61,9 +66,13 @@ func (d *RpmDB) Package(name string) (*PackageInfo, error) {
 }
 
 func (d *RpmDB) ListPackages() ([]*PackageInfo, error) {
+	return d.ListPackagesWithContext(context.TODO())
+}
+
+func (d *RpmDB) ListPackagesWithContext(ctx context.Context) ([]*PackageInfo, error) {
 	var pkgList []*PackageInfo
 
-	for entry := range d.db.Read() {
+	for entry := range d.db.Read(ctx) {
 		if entry.Err != nil {
 			return nil, entry.Err
 		}

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -1,7 +1,9 @@
 package rpmdb
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -761,5 +763,18 @@ func TestRpmDB_Package(t *testing.T) {
 			err = db.Close()
 			require.NoError(t, err)
 		})
+	}
+}
+
+func TestTimeoutPackages(t *testing.T) {
+	db, err := Open("testdata/centos7-many/Packages")
+	require.NoError(t, err)
+	ctxTimesOut, cancelFunc := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	defer cancelFunc()
+	_, err = db.ListPackagesWithContext(ctxTimesOut)
+	if err == nil {
+		t.Errorf("Expected timeout parsing hash page")
+	} else {
+		assert.Equal(t, "timed out parsing hash page", err.Error())
 	}
 }

--- a/pkg/sqlite3/sqlite3.go
+++ b/pkg/sqlite3/sqlite3.go
@@ -2,6 +2,7 @@ package sqlite3
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/binary"
 	"os"
@@ -44,7 +45,7 @@ func Open(path string) (*SQLite3, error) {
 	return &SQLite3{db}, nil
 }
 
-func (db *SQLite3) Read() <-chan dbi.Entry {
+func (db *SQLite3) Read(ctx context.Context) <-chan dbi.Entry {
 	entries := make(chan dbi.Entry)
 
 	go func() {


### PR DESCRIPTION
*Issue #37*

*Description of changes:*

Adds a `context` object to the ListPackages() and related methods (e.g. `Read()` so that a timeout can be implemented for the underlying bdb database parsing.  The `rpmdb` interface is backwards-compatible, and the context timeout is not implemented for other database file types as there the relevant issue does not apply.

Note: the `Read()` interface change is not backwards-compatible, but it seems like an internal method for underlying database parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, as specified by the MIT License.
