### PR TITLE
ndb: add read lock to prevent NDB blob magic error

### DIFF
--- a/pkg/ndb/ndb.go
+++ b/pkg/ndb/ndb.go
@@ -96,6 +96,11 @@ func Open(path string) (*RpmNDB, error) {
 		return nil, err
 	}
 
+	err = syscallFlock(int(file.Fd()), syscallLOCK_SH)
+	if err != nil {
+		return nil, err
+	}
+
 	hdrBuff := ndbHeader{}
 	err = binary.Read(file, binary.LittleEndian, &hdrBuff)
 	if err != nil {
@@ -127,6 +132,7 @@ func Open(path string) (*RpmNDB, error) {
 }
 
 func (db *RpmNDB) Close() error {
+	_ = syscallFlock(int(db.file.Fd()), syscallLOCK_UN)
 	return db.file.Close()
 }
 

--- a/pkg/ndb/syscall_generic.go
+++ b/pkg/ndb/syscall_generic.go
@@ -1,0 +1,16 @@
+//go:build linux || darwin
+
+package ndb
+
+import (
+	"syscall"
+)
+
+const (
+	syscallLOCK_SH = syscall.LOCK_SH
+	syscallLOCK_UN = syscall.LOCK_UN
+)
+
+func syscallFlock(fd int, how int) error {
+	return syscall.Flock(fd, how)
+}

--- a/pkg/ndb/syscall_windows.go
+++ b/pkg/ndb/syscall_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package ndb
+
+const (
+	syscallLOCK_SH = 0
+	syscallLOCK_UN = 0
+)
+
+func syscallFlock(fd int, how int) error {
+	return nil
+}


### PR DESCRIPTION
This error can happen if the ndb packages file is being updated (e.g. zypper up) while we are reading it. The rpm binary uses flock when running rpm -qa on the ndb backend.

*Issue #47*
