### PR TITLE
Fix build constraints for OSes other than Linux

### DIFF
--- a/pkg/ndb/syscall.go
+++ b/pkg/ndb/syscall.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build !linux
 
 package ndb
 

--- a/pkg/ndb/syscall_linux.go
+++ b/pkg/ndb/syscall_linux.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux
 
 package ndb
 


### PR DESCRIPTION
## Description
After [this change](https://github.com/knqyf263/go-rpmdb/pull/48), this library cannot be used for FreeBSD or other OSes than Linux, macOS and Windows. Since the purpose of #48 is to avoid conflicts due to RPMDB updates, it is considered sufficient to lock only on Linux. Therefore, this PR does not lock on other operating systems and can be compiled for other platforms.