### PR TITLE
Avoid heap allocations in Htonl

### DIFF
--- a/pkg/inet.go
+++ b/pkg/inet.go
@@ -1,35 +1,17 @@
 package rpmdb
 
 import (
-	"bytes"
 	"encoding/binary"
-	"log"
 )
 
 func Htonl(val int32) int32 {
-	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.LittleEndian, val); err != nil {
-		log.Println(err)
-		return 0
-	}
-
-	if err := binary.Read(buf, binary.BigEndian, &val); err != nil {
-		log.Println(err)
-		return 0
-	}
-	return val
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(val))
+	return int32(binary.BigEndian.Uint32(buf[:]))
 }
 
 func HtonlU(val uint32) uint32 {
-	buf := new(bytes.Buffer)
-	if err := binary.Write(buf, binary.LittleEndian, val); err != nil {
-		log.Println(err)
-		return 0
-	}
-
-	if err := binary.Read(buf, binary.BigEndian, &val); err != nil {
-		log.Println(err)
-		return 0
-	}
-	return val
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], val)
+	return binary.BigEndian.Uint32(buf[:])
 }

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -119,6 +119,17 @@ func TestPackageList(t *testing.T) {
 			}
 		})
 	}
+
+	for _, tt := range tests {
+		allocs := testing.AllocsPerRun(10, func() {
+			db, err := Open(tt.file)
+			require.NoError(t, err)
+
+			_, err = db.ListPackages()
+			require.NoError(t, err)
+		})
+		t.Logf("Allocations per run %q: %f", tt.name, allocs)
+	}
 }
 
 func TestRpmDB_Package(t *testing.T) {

--- a/pkg/rpmdb_test.go
+++ b/pkg/rpmdb_test.go
@@ -10,8 +10,8 @@ import (
 	_ "github.com/glebarez/go-sqlite"
 )
 
-func TestPackageList(t *testing.T) {
-	tests := []struct {
+var (
+	packageTests = []struct {
 		name    string
 		file    string // Test input file
 		pkgList []*PackageInfo
@@ -87,8 +87,10 @@ func TestPackageList(t *testing.T) {
 			pkgList: Fedora35PlusMongoDBWithSQLite3(),
 		},
 	}
+)
 
-	for _, tt := range tests {
+func TestPackageList(t *testing.T) {
+	for _, tt := range packageTests {
 		t.Run(tt.name, func(t *testing.T) {
 			db, err := Open(tt.file)
 			require.NoError(t, err)
@@ -119,16 +121,23 @@ func TestPackageList(t *testing.T) {
 			}
 		})
 	}
+}
 
-	for _, tt := range tests {
-		allocs := testing.AllocsPerRun(10, func() {
-			db, err := Open(tt.file)
-			require.NoError(t, err)
-
-			_, err = db.ListPackages()
-			require.NoError(t, err)
+func BenchmarkRpmDB_Package(b *testing.B) {
+	for _, tt := range packageTests {
+		b.Run(tt.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				db, err := Open(tt.file)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, err = db.ListPackages()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportAllocs()
 		})
-		t.Logf("Allocations per run %q: %f", tt.name, allocs)
 	}
 }
 


### PR DESCRIPTION
Avoids heap allocations when in Htonl.

```
rpmdb_test.go:131: Allocations per run "CentOS5 plain": from 296182 to 26664
rpmdb_test.go:131: Allocations per run "CentOS6 Plain": from 346814 to 41826
rpmdb_test.go:131: Allocations per run "CentOS6 with Development tools": from 703604 to 82604
rpmdb_test.go:131: Allocations per run "CentOS6 with many packages": from 866345 to 96344
rpmdb_test.go:131: Allocations per run "CentOS7 Plain": from 389679 to 46470
rpmdb_test.go:131: Allocations per run "CentOS7 with Development tools": from 721811 to 100046
rpmdb_test.go:131: Allocations per run "CentOS7 with many packages": from 1061689 to 127268
rpmdb_test.go:131: Allocations per run "CentOS7 with Python 3.5": from 911443 to 106971
rpmdb_test.go:131: Allocations per run "CentOS7 with httpd 2.4": from 588830 to 62563
rpmdb_test.go:131: Allocations per run "CentOS8 with modules": from 1440866 to 136506
rpmdb_test.go:131: Allocations per run "RHEL UBI8 from s390x": from 508158 to 51291
rpmdb_test.go:131: Allocations per run "SLE15 with NDB style rpm database": from 98312 to 5654
rpmdb_test.go:131: Allocations per run "Fedora35 with SQLite3 style rpm database": from 371913 to 22497
rpmdb_test.go:131: Allocations per run "Fedora35 plus MongoDB with SQLite3 style rpm database": from 382463 to 23151
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
