### PR TITLE
GH-56 Open sqlite db in readonly mode to avoid changes to .shm and .wal files

### DIFF
--- a/pkg/sqlite3/sqlite3.go
+++ b/pkg/sqlite3/sqlite3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/binary"
+	"fmt"
 	"os"
 
 	dbi "github.com/knqyf263/go-rpmdb/pkg/db"
@@ -36,7 +37,8 @@ func Open(path string) (*SQLite3, error) {
 		return nil, ErrorInvalidSQLite3
 	}
 
-	db, err := sql.Open("sqlite", path)
+	// open sqlite3 database in read-only mode
+	db, err := sql.Open("sqlite", fmt.Sprintf("file:%s?mode=ro&immutable=1", path))
 	if err != nil {
 		return nil, xerrors.Errorf("failed to open sqlite3: %w", err)
 	}


### PR DESCRIPTION
*Issue #, if available:* #56

*Description of changes:*
When using the library to query the RPM database from rpmdb.sqlite, the library appears to remove the .shm (shared memory) and .wal (write-ahead log) files from the /var/lib/rpm directory. This behavior causes subsequent rpm commands (e.g., rpm -qa) to fail with errors until the rpm command is run with sudo privileges, which recreates the missing files.

This PR opens the db in readonly mode to avoid this issue!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

_Verification_

Before this change:
```
$ rpm -qa | wc -l
442
$ sudo ./rpmdb-master | wc -l
444
$ rpm -qa | wc -l
error: sqlite failure: CREATE TABLE IF NOT EXISTS 'Packages' (hnum INTEGER PRIMARY KEY AUTOINCREMENT,blob BLOB NOT NULL): attempt to write a readonly database
error: cannot open Packages index using sqlite - No such file or directory (2)
error: cannot open Packages database in /var/lib/rpm
0
```

After this change:
```
$ rpm -qa | wc -l
442
]$ sudo ./rpmdb-sqlitefix | wc -l
444
$ rpm -qa | wc -l
442
```
